### PR TITLE
🚨 Mapper のテストコードサンプルを追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+		
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/demo/domain/BookManagementTbl.java
+++ b/src/main/java/com/example/demo/domain/BookManagementTbl.java
@@ -1,0 +1,35 @@
+package com.example.demo.domain;
+
+import lombok.Data;
+
+/**
+ * `book_management_tbl` entity
+ * 
+ * @author azuki
+ *
+ */
+@Data
+public class BookManagementTbl {
+
+	/** ID */
+	private Integer id;
+	
+	/** TITEL */
+	private String title;
+	
+	/** AUTHOR */
+	private String author;
+	
+	/** VERSIONNUMBER */
+	private String versionnumber;
+	
+	/** ISBN */
+	private String isbn;
+	
+	/** BOOKSCOUNT */
+	private Integer bookscount;
+	
+	/** NOTE */
+	private String note;
+	
+}

--- a/src/main/java/com/example/demo/repository/BookManagementTblRepository.java
+++ b/src/main/java/com/example/demo/repository/BookManagementTblRepository.java
@@ -1,0 +1,16 @@
+package com.example.demo.repository;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import com.example.demo.domain.BookManagementTbl;
+
+@Mapper
+public interface BookManagementTblRepository {
+	
+	@Select("SELECT * FROM book_management_tbl")
+    public List<BookManagementTbl> findAll();
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,8 @@ spring.datasource.password=hidetaka1
 spring.mvc.hiddenmethod.filter.enabled=true
 logging.level.org.springframework=WARN
 logging.level.com.example.demo.mapper.BookMngMapper=DEBUG
+mybatis.configuration.map-underscore-to-camel-case=true
 #spring.webflux.hiddenmethod.filter.enabled
-#spring.datasource.schema = classpath：database / schema.sql
-#spring.datasource.data = classpath：database / data.sql
+#spring.datasource.schema = classpath\u00ef\u00bc\u009adatabase / schema.sql
+#spring.datasource.data = classpath\u00ef\u00bc\u009adatabase / data.sql
 #spring.datasource.sql-script-encoding = utf-8

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE if not exists `book_management_tbl` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'ID',
+  `title` varchar(255) NOT NULL COMMENT 'TITLE',
+  `author` varchar(255) NOT NULL COMMENT 'AUTHOR',
+  `versionnumber` varchar(10) NOT NULL COMMENT 'VERSIONNUMBER',
+  `isbn` varchar(20) NOT NULL COMMENT 'ISBN',
+  `bookscount` int(11) NOT NULL COMMENT 'BOOKSCOUNT',
+  `note` varchar(300) DEFAULT NULL COMMENT 'NOTE',
+  PRIMARY KEY (`id`)
+) COMMENT='book_management_tbl';

--- a/src/test/java/com/example/demo/repository/BookManagementTblRepositoryTest.java
+++ b/src/test/java/com/example/demo/repository/BookManagementTblRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.example.demo.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.example.demo.domain.BookManagementTbl;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes=BookManagementTblRepository.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@MybatisTest
+public class BookManagementTblRepositoryTest {
+	
+	BookManagementTblRepository repository;
+
+    @Test
+    @Sql(statements = "INSERT INTO book_management_tbl (id, title, author, versionnumber, isbn, bookscount, note) VALUES (1, 'Java', '中村',  '第二版',  '444', '4', '9')")
+    public void testFindAll() {
+        // execute
+        List<BookManagementTbl> bookManagement = repository.findAll();
+
+        // assert
+        assertThat(bookManagement)
+                .hasSize(1)
+                .extracting(BookManagementTbl::getTitle, BookManagementTbl::getAuthor, BookManagementTbl::getVersionnumber)
+                .containsExactly(tuple("Java", "中村", "第二"));
+    }
+
+}


### PR DESCRIPTION
`book_management_tbl` テーブルを全件検索する場合のテストコードを追加しました。

ベースは [こちら](https://qiita.com/yoshikawaa/items/b694361026c3993472af) の記事です。
僕の環境だと DB の状態が悪いからかコネクション系のエラーが出てしまいますので、取り込んで試してみてもらえると助かります。

### テストクラス
`com.example.demo.repository.BookManagementTblRepositoryTest`